### PR TITLE
Allow importing into projects without Worlds SDK

### DIFF
--- a/Packages/com.bocud.vrcapitools/Editor/ApiFileHelperAsync.cs
+++ b/Packages/com.bocud.vrcapitools/Editor/ApiFileHelperAsync.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using librsync.net;
 using UnityEngine;
 using VRC.Core;
-using VRC.Udon.Serialization.OdinSerializer.Utilities;
 
 using static VRC.Core.ApiFileHelper;
 using Tools = VRC.Tools;
@@ -440,7 +439,7 @@ namespace BocuD.VRChatApiTools
                 }
             });
 
-            if (result.IsNullOrWhitespace()) throw new Exception("File MD5 generation failed");
+            if (string.IsNullOrWhiteSpace(result)) throw new Exception("File MD5 generation failed");
             
             return result;
         }

--- a/Packages/com.bocud.vrcapitools/Editor/BocuD.VRChatApiTools.Editor.asmdef
+++ b/Packages/com.bocud.vrcapitools/Editor/BocuD.VRChatApiTools.Editor.asmdef
@@ -3,7 +3,6 @@
     "references": [
         "VRC.SDKBase",
         "VRC.SDKBase.Editor",
-        "VRC.Udon.Serialization.OdinSerializer",
         "BocuD.VRChatApiTools.Runtime"
     ],
     "includePlatforms": [

--- a/Packages/com.bocud.vrcapitools/Editor/VRChatApiTools.cs
+++ b/Packages/com.bocud.vrcapitools/Editor/VRChatApiTools.cs
@@ -9,7 +9,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using VRC.Core;
-using VRC.SDK3.Components;
+using VRC.SDKBase;
 using Object = UnityEngine.Object;
 
 namespace BocuD.VRChatApiTools
@@ -322,7 +322,7 @@ namespace BocuD.VRChatApiTools
         {
             Scene currentScene = SceneManager.GetActiveScene();
 
-            VRCSceneDescriptor[] sceneDescriptors = Object.FindObjectsOfType<VRCSceneDescriptor>()
+            VRC_SceneDescriptor[] sceneDescriptors = Object.FindObjectsOfType<VRC_SceneDescriptor>()
                 .Where(x => x.gameObject.scene == currentScene).ToArray();
 
             if (sceneDescriptors.Length == 0) return null;

--- a/Packages/com.bocud.vrcapitools/Editor/VRChatApiToolsGUI.cs
+++ b/Packages/com.bocud.vrcapitools/Editor/VRChatApiToolsGUI.cs
@@ -6,7 +6,6 @@ using UnityEditor;
 using UnityEngine;
 using VRC.Core;
 using VRC.SDKBase.Editor;
-using VRC.Udon.Serialization.OdinSerializer.Utilities;
 
 namespace BocuD.VRChatApiTools
 {
@@ -20,7 +19,7 @@ namespace BocuD.VRChatApiTools
         /// <param name="secondaryButtons">Action params that can be implemented to add extra GUI functionality to inspector</param>
         public static void DrawBlueprintInspector(string blueprintID, bool small = true, params Action[] secondaryButtons)
         {
-            if (blueprintID.IsNullOrWhitespace())
+            if (string.IsNullOrWhiteSpace(blueprintID))
             {
                 EditorGUILayout.BeginHorizontal(EditorStyles.helpBox, GUILayout.Height(108));
                 EditorGUILayout.BeginHorizontal();

--- a/Packages/com.bocud.vrcapitools/Editor/VRChatApiToolsUploadStatus.cs
+++ b/Packages/com.bocud.vrcapitools/Editor/VRChatApiToolsUploadStatus.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
-using VRC.Udon.Serialization.OdinSerializer.Utilities;
 
 namespace BocuD.VRChatApiTools
 {
@@ -217,7 +216,7 @@ namespace BocuD.VRChatApiTools
 
         public void SetStatus(string header, string status = null, string subStatus = null)
         {
-            AddLog($"{(_status.IsNullOrWhitespace() ? $"{_header}" : $"{_status}{(_subStatus.IsNullOrWhitespace() ? "" : $": {_subStatus}")}")}");
+            AddLog($"{(string.IsNullOrWhiteSpace(_status) ? $"{_header}" : $"{_status}{(string.IsNullOrWhiteSpace(_subStatus) ? "" : $": {_subStatus}")}")}");
 
             _header = header;
             _status = status;

--- a/Packages/com.bocud.vrcapitools/Editor/VRChatApiUploaderAsync.cs
+++ b/Packages/com.bocud.vrcapitools/Editor/VRChatApiUploaderAsync.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using VRC.Core;
-using VRC.Udon.Serialization.OdinSerializer.Utilities;
 using Debug = UnityEngine.Debug;
 
 namespace BocuD.VRChatApiTools
@@ -108,7 +107,7 @@ namespace BocuD.VRChatApiTools
         /// <exception cref="Exception"></exception>
         public async Task<string> UploadWorld(string assetBundlePath, string unityPackagePath, VRChatApiTools.WorldInfo worldInfo = null)
         {
-            if (assetBundlePath.IsNullOrWhitespace())
+            if (string.IsNullOrWhiteSpace(assetBundlePath))
                 throw new Exception("Invalid null or empty AssetBundle path provided");
             
             VRChatApiTools.ClearCaches();
@@ -198,7 +197,7 @@ namespace BocuD.VRChatApiTools
                     VRChatApiTools.GetFriendlyWorldFileName("Asset bundle", apiWorld, platform), "Asset bundle");
             }
             
-            if (assetBundleUrl.IsNullOrWhitespace()) 
+            if (string.IsNullOrWhiteSpace(assetBundleUrl)) 
             {
                 OnStatus("Failed", "Asset bundle upload failed");
                 return;
@@ -239,8 +238,8 @@ namespace BocuD.VRChatApiTools
                 }
             }
             
-            apiWorld.assetUrl = newAssetUrl.IsNullOrWhitespace() ? apiWorld.assetUrl : newAssetUrl;
-            apiWorld.unityPackageUrl = newPackageUrl.IsNullOrWhitespace() ? apiWorld.unityPackageUrl : newPackageUrl;
+            apiWorld.assetUrl = string.IsNullOrWhiteSpace(newAssetUrl) ? apiWorld.assetUrl : newAssetUrl;
+            apiWorld.unityPackageUrl = string.IsNullOrWhiteSpace(newPackageUrl) ? apiWorld.unityPackageUrl : newPackageUrl;
             
             OnStatus("Applying Blueprint Changes");
             
@@ -306,7 +305,7 @@ namespace BocuD.VRChatApiTools
                 }
             }
 
-            if (newWorld.imageUrl.IsNullOrWhitespace())
+            if (string.IsNullOrWhiteSpace(newWorld.imageUrl))
             {
                 newWorld.imageUrl = await UploadImage(newWorld, SaveImageTemp(new Texture2D(1200, 900)));
             }

--- a/Packages/com.bocud.vrcapitools/Runtime/BocuD.VRChatApiTools.Runtime.asmdef
+++ b/Packages/com.bocud.vrcapitools/Runtime/BocuD.VRChatApiTools.Runtime.asmdef
@@ -1,9 +1,7 @@
 {
     "name": "BocuD.VRChatApiTools.Runtime",
     "references": [
-        "VRC.SDKBase",
-        "VRC.SDKBase.Editor",
-        "VRC.Udon.Serialization.OdinSerializer"
+        "VRC.SDKBase"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
-Replaced VRC.SDK3.Components.VRCSceneDescriptor with VRC.SDKBase.VRC_SceneDescriptor (VRC_SceneDescriptor is the abstract class which VRCSceneDescriptor directly inherits from, and is included in the avatar SDK) ( Fixes #3 )
-Replaced all VRC.Udon.Serialization.OdinSerializer.Utilities.IsNullOfWhitespace() with string.IsNullOrWhiteSpace() in editor assembly ( Fixes #3 )
-Removed obsolete references from runtime assembly

This should be a valid solution for allowing import into projects without Worlds SDK

![image](https://user-images.githubusercontent.com/26690821/185306439-f49b7e46-61e2-4fb7-95f6-ea36aadac300.png)
